### PR TITLE
add support for shared transitions

### DIFF
--- a/react-nativescript-navigation/src/native-stack/types.tsx
+++ b/react-nativescript-navigation/src/native-stack/types.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 // import { StyleProp, ViewStyle, ImageSourcePropType } from 'react-native';
 import { FrameAttributes, NativeScriptProps, RNSStyle } from "react-nativescript";
 import { NavigationButtonAttributes } from "react-nativescript";
-import { ImageSource, Color, Frame } from "@nativescript/core";
+import { ImageSource, Color, Frame, NavigatedData } from "@nativescript/core";
 import { ScreenProps } from '../react-nativescript-screens/screens';
 import {
   DefaultNavigatorOptions,
@@ -30,11 +30,18 @@ export type FrameNavigationEventMap = {
   /**
    * Event which fires when the screen appears.
    */
-  didAppear: { data: undefined };
+  willAppear: { data: NavigatedData };
+
+  /**
+   * Event which fires when the screen appears.
+   */
+  didAppear: { data: NavigatedData };
   /**
    * Event which fires when the current screen is dismissed by hardware back (on Android) or dismiss gesture (swipe back or down).
    */
-  didDisappear: { data: undefined };
+  didDisappear: { data: NavigatedData };
+
+  willDisappear: { data: NavigatedData };
 };
 
 export type FrameNavigationProp<

--- a/react-nativescript-navigation/src/native-stack/views/FrameNavigatorView.tsx
+++ b/react-nativescript-navigation/src/native-stack/views/FrameNavigatorView.tsx
@@ -5,8 +5,8 @@
 import * as React from 'react';
 // import { View, StyleSheet, Platform } from 'react-native';
 import {
-  ScreenStack,
-  Screen as ScreenComponent,
+  NativeScreensProvider as ScreenStack,
+  NativeScreen as ScreenComponent,
   ScreenProps,
 } from '../../react-nativescript-screens/screens';
 import {
@@ -36,7 +36,7 @@ interface TNSFramePrivate extends Frame {
   // _currentEntry: BackstackEntry | undefined,
 
   isCurrent: (entry: BackstackEntry) => boolean,
-  _removeEntry: (entry: BackstackEntry) => void,  
+  _removeEntry: (entry: BackstackEntry) => void,
 }
 
 const Screen = (ScreenComponent as unknown) as React.ComponentType<ScreenProps>;
@@ -46,12 +46,14 @@ const Screen = (ScreenComponent as unknown) as React.ComponentType<ScreenProps>;
  * @see https://github.com/software-mansion/react-native-screens/blob/73959abc975b5718e683d39f1452ec0bb4d5f475/native-stack/views/Frame.tsx#L27
  */
 export default function FrameNavigatorView({
-  state,
-  navigation,
-  descriptors,
   style,
   ...rest
 }: FrameProps) {
+  const {
+    state,
+    navigation,
+    descriptors,
+  } = rest
   // const { colors } = useTheme();
   // console.log(`[Frame] ${JSON.stringify(state.routes.map(route => route.key))}`);
 
@@ -82,11 +84,16 @@ export default function FrameNavigatorView({
             stackAnimation={stackAnimation}
             onWillDisappear={(args: NavigatedData) => {
               // console.log(`[Screen.${route.key} ${args.object}] 'willDisappear'.`);
+              navigation.emit({
+                type: 'willDisappear',
+                target: route.key,
+                data: args
+              });
             }}
             onDidDisappear={(args: NavigatedData) => {
               const page = args.object as Page;
               const frame = page.frame as TNSFramePrivate;
-              if(frame?._currentEntry?.resolvedPage){
+              if (frame?._currentEntry?.resolvedPage) {
                 // console.log(`[Screen.${route.key} ${args.object}] 'didDisappear'. Still currentPage.`);
                 // "First" screen fires this upon disappearing when navigating forward to "Second" via React Navigation.
                 // "Second" screen fires this upon disappearing when navigating backward to "First" via React Navigation.
@@ -131,6 +138,11 @@ export default function FrameNavigatorView({
             }}
             onWillAppear={(args: NavigatedData) => {
               // console.log(`[Screen.${route.key} ${args.object}] 'willAppear'.`);
+              navigation.emit({
+                type: 'willAppear',
+                target: route.key,
+                data: args
+              });
             }}
             onDidAppear={(args: NavigatedData) => {
               // Software Mansion's Frame chooses to emit before the dispatch.
@@ -142,12 +154,12 @@ export default function FrameNavigatorView({
               const page = args.object as Page;
               const frame = page.frame as TNSFramePrivate;
 
-              if(frame?._currentEntry?.resolvedPage === page){
+              if (frame?._currentEntry?.resolvedPage === page) {
                 // "Second" screen fires this upon appearing when being navigating forward to from "First" via React Navigation.
                 // "First" screen fires this upon appearing when being navigating backward to from "Second" via React Navigation.
                 // "First" screen fires this upon appearing when being navigating backward to from "Second" via user.
                 // console.log(`[Screen.${route.key} ${args.object}] 'didAppear', becoming currentPage. active: ${active}`);
-                if(!active){
+                if (!active) {
                   const topRoute = state.routes[state.routes.length - 1];
                   navigation.dispatch({
                     ...StackActions.pop(),
@@ -159,7 +171,7 @@ export default function FrameNavigatorView({
                 // console.log(`[Screen.${route.key} ${args.object}] 'didAppear', but not becoming currentPage.`);
               }
             }}
-            >
+          >
             <HeaderConfig {...options} route={route} />
             <flexboxLayout
               nodeRole={"content"}

--- a/react-nativescript-navigation/src/react-nativescript-screens/screens.tsx
+++ b/react-nativescript-navigation/src/react-nativescript-screens/screens.tsx
@@ -501,13 +501,11 @@ export const NativeScreensProvider: React.FC<FrameProps> = ({ children, ...rest 
   }
 
   function $goBack() {
-    if (!navRef.current) return
-    if (navRef.current.nativeView.canGoBack()) navRef.current.nativeView.goBack()
+    if (Frame.topmost().canGoBack()) Frame.topmost().goBack()
   }
 
   function $closeModal() {
-    if (!navRef.current) return
-    navRef.current.nativeView.closeModal()
+    Frame.topmost().closeModal()
   }
   return (
     <NativeScreensContext.Provider value={{

--- a/react-nativescript-navigation/src/react-nativescript-screens/screens.tsx
+++ b/react-nativescript-navigation/src/react-nativescript-screens/screens.tsx
@@ -500,4 +500,4 @@ export const NativeScreensProvider: React.FC<FrameProps> = ({ children, ...rest 
   )
 }
 
-export const useNativeScreenContext = () => React.useContext(NativeScreensContext)
+export const useNativeScreensContext = () => React.useContext(NativeScreensContext)

--- a/react-nativescript-navigation/src/react-nativescript-screens/screens.tsx
+++ b/react-nativescript-navigation/src/react-nativescript-screens/screens.tsx
@@ -477,6 +477,7 @@ export const NativeScreensProvider: React.FC<FrameProps> = ({ children, ...rest 
   }
   function $navigate<T>(params: GoToScreenParams<T>) {
     createView(params, (page) => {
+      page.actionBarHidden = !!params.pageProps?.actionBarHidden
       navRef.current.nativeView.navigate({
         create() {
           return page

--- a/react-nativescript-navigation/src/react-nativescript-screens/screens.tsx
+++ b/react-nativescript-navigation/src/react-nativescript-screens/screens.tsx
@@ -4,8 +4,9 @@
  */
 import * as React from 'react';
 import { PropsWithChildren } from 'react';
-import { RNSStyle, PageAttributes, FlexboxLayoutAttributes, NavigationButtonAttributes, ActionBarAttributes, ActionItemAttributes, NSVElement } from "react-nativescript";
-import { NavigatedData, Color } from "@nativescript/core";
+import { RNSStyle, PageAttributes, FlexboxLayoutAttributes, NavigationButtonAttributes, ActionBarAttributes, ActionItemAttributes, NSVElement, render } from "react-nativescript";
+import { NavigatedData, Color, Page, Frame, NavigationTransition, ContainerView, EventData, ContentView } from "@nativescript/core";
+import { FrameProps } from 'src/native-stack/types';
 
 type StyleProp<T> = T;
 type TextStyle = RNSStyle;
@@ -178,81 +179,67 @@ export interface ScreenStackHeaderConfigProps extends FlexboxLayoutAttributes {
   children?: React.ReactNode;
 }
 
-interface NativeScreenState {
-  onscreen: boolean,
-}
 
 /**
  * @see https://github.com/software-mansion/react-native-screens/blob/master/src/screens.web.js
  * @see https://docs.nativescript.org/ui/components/page#page-events
  */
-export class NativeScreen extends React.Component<ScreenProps, NativeScreenState> {
-  // Strictly, this is an NSVElement<Page>, but I'm hitting a TSC error – probably a @nativescript/core version mismatch in my dependencies.
-  private readonly ref = React.createRef<NSVElement<any>>();
 
-  constructor(props: ScreenProps){
-    super(props);
-
-    this.state = {
-      onscreen: props.active === 1,
-    };
-  }
-
+export const NativeScreen: React.FC<ScreenProps> = (props) => {
+  const { active, gestureEnabled, style, ...rest } = props;
+  const [onScreen, setOnScreen] = React.useState<boolean>(() => props.active === 1)
+  const ref = React.useRef<NSVElement<Page>>()
   // 1
-  private readonly onNavigatingFrom = (args: NavigatedData) => {
-    this.props.onWillDisappear?.(args); // √
+  const onNavigatingFrom = (args: NavigatedData) => {
+    props.onWillDisappear?.(args); // √
   };
-  
+
   // 2
-  private readonly onNavigatingTo = (args: NavigatedData) => {
+  const onNavigatingTo = (args: NavigatedData) => {
     // Checking whether our ref is still populated avoids "Can't perform a React state update on an unmounted component."
-    if(this.ref.current){
-      this.setState({ onscreen: true });
+    if (ref.current) {
+      setOnScreen(true);
     }
-    this.props.onWillAppear?.(args);
+    props.onWillAppear?.(args);
   };
-  
+
   // 3
-  private readonly onNavigatedFrom = (args: NavigatedData) => {
-    this.props.onDidDisappear?.(args);
+  const onNavigatedFrom = (args: NavigatedData) => {
+    props.onDidDisappear?.(args);
     // Checking whether our ref is still populated avoids "Can't perform a React state update on an unmounted component."
-    if(this.ref.current){
-      this.setState({ onscreen: false });
+    if (ref.current) {
+      setOnScreen(false)
     }
   };
-  
+
   // 4
-  private readonly onNavigatedTo = (args: NavigatedData) => {
-    this.props.onDidAppear?.(args);
+  const onNavigatedTo = (args: NavigatedData) => {
+    props.onDidAppear?.(args);
   };
 
-  render(){
-    const { active, gestureEnabled, style, ...rest } = this.props;
+  // console.log(`[NativeScreen] ENABLE_SCREENS && !active ${ENABLE_SCREENS && !active}`);
 
-    // console.log(`[NativeScreen] ENABLE_SCREENS && !active ${ENABLE_SCREENS && !active}`);
-
-    return (
-      <page
-        ref={this.ref}
-        enableSwipeBackNavigation={gestureEnabled}
-        onNavigatingTo={this.onNavigatingTo}
-        onNavigatedTo={this.onNavigatedTo}
-        onNavigatedFrom={this.onNavigatedFrom}
-        onNavigatingFrom={this.onNavigatingFrom}
-        style={{
-          ...style,
-          ...(
-            ENABLE_SCREENS && !active && !this.state.onscreen ? 
-              {
-                visibility: 'collapse' // Because `display: 'none'` doesn't exist in NativeScript
-              } : 
-              {}
-          ),
-        }}
-        {...rest}
-      />
-    );
-  }
+  return (
+    <page
+      ref={ref}
+      enableSwipeBackNavigation={gestureEnabled}
+      onNavigatingTo={onNavigatingTo}
+      onNavigatedTo={onNavigatedTo}
+      onNavigatedFrom={onNavigatedFrom}
+      onNavigatingFrom={onNavigatingFrom}
+      style={{
+        ...style,
+        ...(
+          ENABLE_SCREENS && !active && !onScreen ?
+            {
+              visibility: 'collapse' // Because `display: 'none'` doesn't exist in NativeScript
+            } :
+            {}
+        ),
+      }}
+      {...rest}
+    />
+  );
 }
 
 const styles = {
@@ -442,3 +429,75 @@ export const NativeScreenContainer: React.ElementType<JSX.IntrinsicElements["fle
 
 // ScreenStack contains any number of Screen components.
 export const ScreenStack: React.ElementType<JSX.IntrinsicElements["frame"]> = "frame";
+
+type GoToScreenParams<T> = {
+  screen: React.JSXElementConstructor<T>,
+  props?: T,
+  transition?: NavigationTransition,
+  pageProps?: ScreenProps
+}
+interface NativeScreensContextData {
+  $showModal<T>(params: GoToScreenParams<T>): void
+  $navigate<T>(params: GoToScreenParams<T>): void
+}
+
+const NativeScreensContext = React.createContext({} as NativeScreensContextData)
+
+export const NativeScreensProvider: React.FC<FrameProps> = ({ children, ...rest }) => {
+  const navRef = React.useRef<NSVElement<Frame>>()
+  function createView<T>(params: GoToScreenParams<T>, callback = (page: Page) => { }, modal?: boolean) {
+    const { screen: Screen, props } = params
+    if (!navRef.current) return
+    const ref = React.createRef<NSVElement<ContentView>>()
+    const container = new NSVElement<Page>('page')
+    if (modal) container.nativeView.background = 'transparent'
+    const key = `${Date.now()}-screen`
+    render(
+      (
+        <NativeScreensProvider {...rest}>
+          <NativeScreen {...params.pageProps} active={1} key={key}>
+            <Screen {...props ? props : undefined} />
+          </NativeScreen>
+        </NativeScreensProvider>
+      ),
+      container, () => callback(container.nativeView), key, true)
+  }
+  function $showModal<T>(params: GoToScreenParams<T>, fullScreen?: boolean) {
+    createView(params, (page) => {
+      navRef.current.nativeView.showModal(page, {
+        animated: true,
+        transparent: true,
+        fullscreen: fullScreen,
+        context: params.props,
+        closeCallback: (_args: any) => {
+
+        }
+      });
+    })
+  }
+  function $navigate<T>(params: GoToScreenParams<T>) {
+    createView(params, (page) => {
+      navRef.current.nativeView.navigate({
+        create() {
+          return page
+        },
+        transition: params.transition,
+        backstackVisible: true,
+        context: params.props,
+        animated: true,
+      })
+    })
+  }
+  return (
+    <NativeScreensContext.Provider value={{
+      $navigate,
+      $showModal,
+    }}>
+      <frame {...rest} ref={navRef}>
+        {children}
+      </frame>
+    </NativeScreensContext.Provider>
+  )
+}
+
+export const useNativeScreenContext = () => React.useContext(NativeScreensContext)


### PR DESCRIPTION
Added support for https://beta.docs.nativescript.org/guide/shared-element-transitions, exposes `$navigate` (can be used to apply the shared Elements Transitions) and `$showModal` as inspired by `nativescript-vue`.

Usage:
```TS
const HomePage = () => {
 const { $navigate } = useNativeScreensContext();

 // call the $navigate method
$navigate({
      screen: ShareTransionScreenTest,
      props: {
        userId: 1,
      },
      transition: SharedTransition.custom(new PageTransition(), {
        pageStart: {
          x: 0,
          y: 300,
          opacity: 0,
          height: 0,
        },
        pageEnd: {
          x: 0,
          y: 100,
          duration: 256,
          opacity: 1,
        },
        pageReturn: {
          y: 600,
          duration: 250,
          useStartOpacity: true,
        }
      }),
      pageProps: {
        stackPresentation: 'push',
        actionBarHidden: true,
        gestureEnabled: true,
      }
    })
}
```